### PR TITLE
Avoid problems with System.InvalidCastException when opening file

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -224,12 +224,12 @@ namespace ClosedXML.Excel
                 // Although relationship to worksheet is most common, there can be other types
                 // than worksheet, e.g. chartSheet. Since we can't load them, add them to list
                 // of unsupported sheets and copy them when saving. See Codeplex #6932.
-                var worksheetPart = workbookPart.GetPartById(dSheet.Id) as WorksheetPart;
-                if (worksheetPart == null)
+                if (!(workbookPart.GetPartById(dSheet.Id) is WorksheetPart))
                 {
                     UnsupportedSheets.Add(new UnsupportedSheet { SheetId = sheetId, Position = position });
                     continue;
                 }
+                var worksheetPart = workbookPart.GetPartById(dSheet.Id) as WorksheetPart;
 
                 var sharedFormulasR1C1 = new Dictionary<UInt32, String>();
                 var ws = WorksheetsInternal.Add(sheetName, position, sheetId);


### PR DESCRIPTION
After building 0.102.2 on .NET 8, I tried opening an XLSX file (freshly converted form XLS) and I encountered an exception while trying to open this file: 

System.InvalidCastException: Unable to cast object of type 'DocumentFormat.OpenXml.Packaging.DialogsheetPart' to type 'DocumentFormat.OpenXml.Packaging.WorksheetPart'.
   at ClosedXML.Excel.XLWorkbook.LoadSpreadsheetDocument(SpreadsheetDocument dSpreadsheet)
   at ClosedXML.Excel.XLWorkbook.LoadSheets(Stream stream)
   at ClosedXML.Excel.XLWorkbook.Load(Stream stream)
   at ClosedXML.Excel.XLWorkbook..ctor(Stream stream, LoadOptions loadOptions)
   at ClosedXML.Excel.XLWorkbook..ctor(Stream stream)
/* trace of my code from this point */ 

The 'as' operator shouldn't behave like this. However checking with 'is' before converting with 'as' should, in theory, ensure that 'as' will not(never?) fail as everything past the check 'is' a WorkbookPart. Nothing else in the code (LoadSpreadsheetDocument method), as far as I can find it, could potentially throw an InvalidCastException. 

Should someone know something more about this, then I would like to know...